### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Animated scrolling to a specified id.
 
 ```bash
 # From within your ember-cli project
-ember install:addon ember-scroll-to
+ember install ember-scroll-to
 ```
 
 ## Usage


### PR DESCRIPTION
Current versions of ember-cli use `ember install [npm-module-name]`
