### PR TITLE
Refactor to abstract jQuery away and to call scrolling programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,33 @@
 # ember-scroll-to
 
-Animated scrolling to a specified id.
+Animated vertical scrolling to a specified id.
+
 
 ## Installation
 
+From within your ember-cli project directory: 
+
 ```bash
-# From within your ember-cli project
 ember install ember-scroll-to
 ```
 
-## Usage
+
+## The component
+
+The `{{scroll-to}}` creates an `<a>` element that, when clicked, scrolls to the specified selector.
 
 In your template:
 
 ```hbs
 {{scroll-to href='#faq' label='FAQ'}}
-{{!-- or --}}
-{{#scroll-to href='#faq'}}FAQ{{/scroll-to}}
+```
+
+You can also use the block form:
+
+```hbs
+{{#scroll-to href='#faq'}}
+  FAQ
+{{/scroll-to}}
 ```
 
 If you want to perform some action after scroll:
@@ -25,30 +36,48 @@ If you want to perform some action after scroll:
 {{scroll-to href='#faq' afterScroll='customAction'}}
 ```
 
-## Options
+The component accepts the following options
 
-### Duration
-Number of milliseconds for the transition to occur over. Default is 750ms.
-
-Example usage:
-```hbs
-{{scroll-to href='#faq' label='FAQ' duration=1000}}
-```
-
-### Easing
-The jQuery animate transition to use. Default is 'swing'. With a standard setup,
+* `href` -- (required) a selector of an element to scroll to on click.
+* `label` -- text to display on the component. Ignored when used in a block form.
+* `duration` -- number of milliseconds for the transition to occur over. Default is 750ms.
+* `easing` -- the jQuery animate transition to use. Default is 'swing'. With a standard setup,
 you could also use 'linear'. If you want more, check out [jQuery UI](http://jqueryui.com/).
-
-Example usage:
-```hbs
-{{scroll-to href='#faq' label='FAQ' easing='linear'}}
-```
-
-### Offset
-An optional offset. The most common use case for this is if you have a fixed header
+* `offset` -- An optional offset. The most common use case for this is if you have a fixed header
 that you need to account for.
 
-Example usage (with a 60px tall fixed header):
+Example usage with all options at once:
+
 ```hbs
-{{scroll-to href='#faq' label='FAQ' offset=-60}}
+{{scroll-to
+  href='#faq'
+  label='FAQ'
+  duration=1000
+  easing='linear'
+  offset=-60
+}}
 ```
+
+
+## Service
+
+You can also invoke scrolling programmatically. To do so, inject the `scroller` service into your object:
+
+```js
+scroller: Ember.inject.service()
+```
+
+Then you can use the `scrollVertical` method on it:
+
+```
+this.get('scroller').scrollVertical(target, options);
+```
+
+`target` can be anything that jQuery accepts (selector, element, jQuery collection...).
+
+`options` is a hash with any of the following key-value pairs (all optional):
+
+* `offset`
+* `duration`
+* `easing`
+* `complete` -- a callback to execute once the scrolling animation is complete.

--- a/addon/components/scroll-to.js
+++ b/addon/components/scroll-to.js
@@ -1,37 +1,46 @@
 import Em from 'ember';
 
-const DURATION = 750;
-const EASING = 'swing';
-const OFFSET = 0;
-
 export default Em.Component.extend({
-  tagName: 'a',
-  href: null,
-  duration: DURATION,
-  easing: EASING,
-  offset: OFFSET,
+
+  // ----- Arguments -----
+  href:     null,      // Required
+  label:    undefined,
+  duration: undefined,
+  easing:   undefined,
+  offset:   undefined,
+
+
+  // ----- Overridden properties -----
+  tagName:           'a',
   attributeBindings: ['href'],
 
-  scrollable: Em.computed(function() {
-    return Em.$('html, body');
+
+  // ----- Services -----
+  scroller: Em.inject.service(),
+
+
+  // ----- Computed properties -----
+  jQueryElement: Em.computed('href', function() {
+    const href = this.get('href');
+
+    return this
+      .get('scroller')
+      .getJQueryElement(href);
   }),
 
-  target: Em.computed('href', function() {
-    const elem = Em.$(this.get('href'));
-    if (!elem) {
-      Em.Logger.warn(`element ${this.get('href')} couldn\'t be found`);
-      return;
-    }
 
-    return elem.offset().top + this.get('offset');
-  }),
-
+  // ----- Events -----
   scroll: Em.on('click', function(evt) {
     evt.stopPropagation();
     evt.preventDefault();
 
-    this.get('scrollable').animate({
-      scrollTop: this.get('target')
-    }, this.get('duration'), this.get('easing'), Em.run.bind(this, this.sendAction, 'afterScroll'));
+    this
+      .get('scroller')
+      .scrollVertical(this.get('jQueryElement'), {
+        duration: this.get('duration'),
+        offset:   this.get('offset'),
+        easing:   this.get('easing'),
+        complete: () => Em.run(this, this.sendAction, 'afterScroll')
+      });
   })
 });

--- a/addon/services/scroller.js
+++ b/addon/services/scroller.js
@@ -1,0 +1,47 @@
+import Em from 'ember';
+
+const DURATION = 750;
+const EASING   = 'swing';
+const OFFSET   = 0;
+
+export default Em.Service.extend({
+
+  // ----- Static properties -----
+  duration: DURATION,
+  easing:   EASING,
+  offset:   OFFSET,
+
+
+  // ----- Computed properties -----
+  scrollable: Em.computed(function() {
+    return Em.$('html, body');
+  }),
+
+
+  // ----- Methods -----
+  getJQueryElement (target) {
+    const jQueryElement = Em.$(target);
+
+    if (!jQueryElement) {
+      Em.Logger.warn("element couldn't be found:", target);
+      return;
+    }
+
+    return jQueryElement;
+  },
+
+  getVerticalCoord (target, offset = 0) {
+    const  jQueryElement = this.getJQueryElement(target);
+    return jQueryElement.offset().top + offset;
+  },
+
+  scrollVertical (target, opts) {
+    this.get('scrollable').animate({
+      scrollTop: this.getVerticalCoord(target, opts.offset)
+    },
+      opts.duration || this.get('duration'),
+      opts.easing   || this.get('easing'),
+      opts.complete
+    );
+  }
+});

--- a/app/services/scroller.js
+++ b/app/services/scroller.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-scroll-to/services/scroller';


### PR DESCRIPTION
All scrolling logic is abstracted into a service that is used in the `scroll-to` component and can be used in any Ember entity.

jQuery logic is hidden within the service. When Ember gets rid of jQuery, this addon can be updated with little impact on users.
