### PR TITLE
Allow calling `scrollVertical` with only the target

### DIFF
--- a/addon/services/scroller.js
+++ b/addon/services/scroller.js
@@ -35,7 +35,7 @@ export default Em.Service.extend({
     return jQueryElement.offset().top + offset;
   },
 
-  scrollVertical (target, opts) {
+  scrollVertical (target, opts = {}) {
     this.get('scrollable').animate({
       scrollTop: this.getVerticalCoord(target, opts.offset)
     },


### PR DESCRIPTION
Hi, 
I noticed that all options for the `scrollVertical` method of the service are optional but you need to pass an empty object as options. 

This PR makes the `opts` default to an empty object, allowing us to call `scrollVertical('target')` instead of `scrollVertical('target', {})`
