### PR TITLE
Update htmlbars to resolve deprecation warning about not caling this._super 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
-    "ember-cli-htmlbars": "0.7.9"
+    "ember-cli-htmlbars": "^1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Solves this error: 

```
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-htmlbars`
    at Function.Addon.lookup (/Users/tim/git/blackbeard/gynzy-dragonglass/node_modules/ember-cli/lib/models/addon.js:896:27)
```

This happens because ember 2.6+ is stricter and throws this deprecation warning. This is solved by using the latest version of ember-cli-htmlbars. 

It would be awesome if you could merge this and create a 0.5.2 release soon ❤️ 
