### PR TITLE
Fixed problem with scrolling in overwritten 'scrollable' element

### DIFF
--- a/addon/services/scroller.js
+++ b/addon/services/scroller.js
@@ -37,7 +37,7 @@ export default Em.Service.extend({
 
   scrollVertical (target, opts = {}) {
     this.get('scrollable').animate({
-      scrollTop: this.getVerticalCoord(target, opts.offset)
+      scrollTop: scrollTop: this.get('scrollable').scrollTop() - this.get('scrollable').offset().top + this.getVerticalCoord(target, opts.offset)
     },
       opts.duration || this.get('duration'),
       opts.easing   || this.get('easing'),

--- a/addon/services/scroller.js
+++ b/addon/services/scroller.js
@@ -37,7 +37,7 @@ export default Em.Service.extend({
 
   scrollVertical (target, opts = {}) {
     this.get('scrollable').animate({
-      scrollTop: scrollTop: this.get('scrollable').scrollTop() - this.get('scrollable').offset().top + this.getVerticalCoord(target, opts.offset)
+      scrollTop: this.get('scrollable').scrollTop() - this.get('scrollable').offset().top + this.getVerticalCoord(target, opts.offset)
     },
       opts.duration || this.get('duration'),
       opts.easing   || this.get('easing'),


### PR DESCRIPTION
A bug currently exists with scrolling when you've overwritten the scrollable element using a service as outlined in the readme, but that element is not the same size as the document. 

Inside the `getVerticalCoord` method the service uses the `jQueryElement.offset().top + offset;` return value which is getting the position of the element relative to the document, if the document is larger than the scrollable area that the custom service overwrites, then the measurement is going to be off creating an unpredictable scroll. This also can create a situation where clicking the same "scroll-to" element multiple times can cause the scrollable element to bounce between two scroll points.
