### PR TITLE
Return promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ this.get('scroller').scrollVertical(target, options);
 * `easing`
 * `complete` -- a callback to execute once the scrolling animation is complete.
 
+The method returns a Promise that will resolve as soon as the animation has completed.
+
 ## Configuration
 Some frameworks - like Google's Material Design Lite - will use a custom DOM structure to wrap the main content (e.g. for facilitating responsive design, modal overlays). For use in such environments, you'll want to override the default scrollable element (`html, body`) with the container element that should be used by the service to set the vertical scroll position. To do so, extend the service:
 ```javascript

--- a/addon/services/scroller.js
+++ b/addon/services/scroller.js
@@ -4,6 +4,8 @@ const DURATION = 750;
 const EASING   = 'swing';
 const OFFSET   = 0;
 
+const { RSVP } = Em;
+
 export default Em.Service.extend({
 
   // ----- Static properties -----
@@ -36,12 +38,19 @@ export default Em.Service.extend({
   },
 
   scrollVertical (target, opts = {}) {
-    this.get('scrollable').animate({
-      scrollTop: this.get('scrollable').scrollTop() - this.get('scrollable').offset().top + this.getVerticalCoord(target, opts.offset)
-    },
-      opts.duration || this.get('duration'),
-      opts.easing   || this.get('easing'),
-      opts.complete
-    );
+    return new RSVP.Promise((resolve) => {
+      this.get('scrollable').animate({
+          scrollTop: this.get('scrollable').scrollTop() - this.get('scrollable').offset().top + this.getVerticalCoord(target, opts.offset)
+        },
+        opts.duration || this.get('duration'),
+        opts.easing   || this.get('easing'),
+        function() {
+          if (typeof opts.complete === 'function') {
+            opts.complete.apply(this, arguments);
+          }
+          resolve();
+        }
+      );
+    });
   }
 });

--- a/addon/services/scroller.js
+++ b/addon/services/scroller.js
@@ -38,19 +38,18 @@ export default Em.Service.extend({
   },
 
   scrollVertical (target, opts = {}) {
-    return new RSVP.Promise((resolve) => {
-      this.get('scrollable').animate({
-          scrollTop: this.get('scrollable').scrollTop() - this.get('scrollable').offset().top + this.getVerticalCoord(target, opts.offset)
-        },
-        opts.duration || this.get('duration'),
-        opts.easing   || this.get('easing'),
-        function() {
-          if (typeof opts.complete === 'function') {
-            opts.complete.apply(this, arguments);
-          }
-          resolve();
-        }
-      );
+    return new RSVP.Promise((resolve, reject) => {
+      this.get('scrollable')
+        .animate(
+          {
+            scrollTop: this.get('scrollable').scrollTop() - this.get('scrollable').offset().top + this.getVerticalCoord(target, opts.offset)
+          },
+          opts.duration || this.get('duration'),
+          opts.easing || this.get('easing'),
+          opts.complete
+        )
+        .promise()
+        .then(resolve, reject);
     });
   }
 });


### PR DESCRIPTION
Although there already was the `opts.complete` callback from jQuery you could use to wait for the animation to complete, working with Promises feels much more "emberish", so here we go...

It will still support the callback, to be backwards compatible!
