### PR TITLE
Added support for horizontal scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The component accepts the following options
 you could also use 'linear'. If you want more, check out [jQuery UI](http://jqueryui.com/).
 * `offset` -- An optional offset. The most common use case for this is if you have a fixed header
 that you need to account for.
+* `direction` -- 'vertical' or 'horizontal'. Vertical by default.
 
 Example usage with all options at once:
 
@@ -55,6 +56,7 @@ Example usage with all options at once:
   duration=1000
   easing='linear'
   offset=-60
+  direction='vertical'
 }}
 ```
 
@@ -67,10 +69,10 @@ You can also invoke scrolling programmatically. To do so, inject the `scroller` 
 scroller: Ember.inject.service()
 ```
 
-Then you can use the `scrollVertical` method on it:
+Then you can use the `scrollElement` method on it:
 
 ```
-this.get('scroller').scrollVertical(target, options);
+this.get('scroller').scrollElement(target, options);
 ```
 
 `target` can be anything that jQuery accepts (selector, element, jQuery collection...).
@@ -80,6 +82,7 @@ this.get('scroller').scrollVertical(target, options);
 * `offset`
 * `duration`
 * `easing`
+* `direction`
 * `complete` -- a callback to execute once the scrolling animation is complete.
 
 The method returns a Promise that will resolve as soon as the animation has completed.

--- a/addon/components/scroll-to.js
+++ b/addon/components/scroll-to.js
@@ -8,7 +8,7 @@ export default Em.Component.extend({
   duration: undefined,
   easing:   undefined,
   offset:   undefined,
-
+  direction: undefined,
 
   // ----- Overridden properties -----
   tagName:           'a',
@@ -36,10 +36,11 @@ export default Em.Component.extend({
 
     this
       .get('scroller')
-      .scrollVertical(this.get('jQueryElement'), {
+      .scrollElement(this.get('jQueryElement'), {
         duration: this.get('duration'),
         offset:   this.get('offset'),
         easing:   this.get('easing'),
+        direction: this.get('direction'),
         complete: () => Em.run(this, this.sendAction, 'afterScroll')
       });
   })

--- a/addon/services/scroller.js
+++ b/addon/services/scroller.js
@@ -36,20 +36,42 @@ export default Em.Service.extend({
     const  jQueryElement = this.getJQueryElement(target);
     return jQueryElement.offset().top + offset;
   },
+  
+  getHorizontalCoord(target, offset = 0) {
+		const jQueryElement = this.getJQueryElement(target);
+		return jQueryElement.offset().left + offset;
+	},
 
-  scrollVertical (target, opts = {}) {
-    return new RSVP.Promise((resolve, reject) => {
-      this.get('scrollable')
-        .animate(
-          {
-            scrollTop: this.get('scrollable').scrollTop() - this.get('scrollable').offset().top + this.getVerticalCoord(target, opts.offset)
-          },
-          opts.duration || this.get('duration'),
-          opts.easing || this.get('easing'),
-          opts.complete
-        )
-        .promise()
-        .then(resolve, reject);
-    });
-  }
+  scrollElement(target, opts = {}) {
+		return new RSVP.Promise((resolve, reject) => {
+
+			var scrollAnimation = {};
+			if(opts.direction === 'horizontal') {
+				scrollAnimation.scrollLeft =  this.get('scrollable').scrollLeft() - this.get('scrollable').offset().left + this.getHorizontalCoord(target, opts.offset);
+			} else {
+				scrollAnimation.scrollTop = this.get('scrollable').scrollTop() - this.get('scrollable').offset().top + this.getVerticalCoord(target, opts.offset);
+			}
+			
+			this.get('scrollable')
+				.animate(scrollAnimation,
+					opts.duration || this.get('duration'),
+					opts.easing || this.get('easing'),
+					opts.complete
+				)
+				.promise()
+				.then(resolve, reject);
+		});
+	},
+  
+  // Keep existing scrollVertical() for backwards compatibility
+	scrollVertical(target, opts = {}) {
+		// Vertical by default
+		return this.scrollElement(target,opts);
+	},
+	
+	scrollHorizontal(target, opts = {}) {
+		// Set direction to horizontal
+		opts.direction = 'horizontal';
+		return this.scrollElement(target,opts);
+	}
 });


### PR DESCRIPTION
Now you can define a `direction` option (if left undefined, defaults to 'vertical'). This direction option is passed to the service, where (if direction is 'horizontal') it does essentially the same calculations but on scrollLeft (rather than scrollTop).

`scrollVertical(...)` becomes `scrollElement(...)` but I have left scrollVertical in for backwards compatibility.

Pretty straightforward really, let me know if any further changes are required.