### PR TITLE
Ensures targets top is only offset by the scrollable's top when appropriate

### DIFF
--- a/addon/services/scroller.js
+++ b/addon/services/scroller.js
@@ -32,17 +32,29 @@ export default Em.Service.extend({
     return jQueryElement;
   },
 
+  getScrollableTop () {
+    // because the target elements top is calculated relative to the document,
+    // and if the scrollable container is not the document,
+    // we need to normalize the target elements top based on the top and current scrolled position of the scrollable
+    if (this.get('scrollable').offset().top) {
+      return this.get('scrollable').scrollTop() - this.get('scrollable').offset().top;
+    } else {
+      return 0;
+    }
+  },
+
   getVerticalCoord (target, offset = 0) {
     const  jQueryElement = this.getJQueryElement(target);
-    return jQueryElement.offset().top + offset;
+    return this.getScrollableTop() + jQueryElement.offset().top + offset;
   },
 
   scrollVertical (target, opts = {}) {
     return new RSVP.Promise((resolve, reject) => {
+
       this.get('scrollable')
         .animate(
           {
-            scrollTop: this.get('scrollable').scrollTop() - this.get('scrollable').offset().top + this.getVerticalCoord(target, opts.offset)
+            scrollTop: this.getVerticalCoord(target, opts.offset)
           },
           opts.duration || this.get('duration'),
           opts.easing || this.get('easing'),

--- a/tests/dummy/app/components/scroll-to-custom-scrollable.js
+++ b/tests/dummy/app/components/scroll-to-custom-scrollable.js
@@ -1,0 +1,12 @@
+import ScrollToComponent from 'ember-scroll-to/components/scroll-to';
+import Ember from 'ember';
+
+const {
+  inject: {
+    service,
+  },
+} = Ember;
+
+export default ScrollToComponent.extend({
+  scroller: service('custom-scrollable'),
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,8 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('simple');
+  this.route('customScrollable');
 });
 
 export default Router;

--- a/tests/dummy/app/services/custom-scrollable.js
+++ b/tests/dummy/app/services/custom-scrollable.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+import ScrollerService from 'ember-scroll-to/services/scroller'
+
+const {
+  computed,
+  $,
+} = Ember;
+
+export default ScrollerService.extend({
+  scrollable: computed(function() {
+    return $('#scrollable-container');
+  }),
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,15 @@
-<h2 id="title">Welcome to Ember.js</h2>
+<h1 id="title">Welcome to Ember.js</h1>
+
+<div>
+  {{#link-to 'simple'}}
+  Simple Example
+  {{/link-to}}
+</div>
+
+<div>
+  {{#link-to 'customScrollable'}}
+  Custom Scrollable
+  {{/link-to}}
+</div>
 
 {{outlet}}

--- a/tests/dummy/app/templates/custom-scrollable.hbs
+++ b/tests/dummy/app/templates/custom-scrollable.hbs
@@ -1,0 +1,54 @@
+<h2>This demonstrates when the scrollable is not the body</h2>
+
+<div style='position: fixed; top: 40px; right: 40px; color: black; background-color: lightGrey; padding: 5px;'>
+  <h3 style='color: black;'>Scroll Nav Menu</h3>
+  <div>
+    {{#scroll-to-custom-scrollable href='#position-1'}}
+    Position 1
+    {{/scroll-to-custom-scrollable}}
+  </div>
+
+  <div>
+    {{#scroll-to-custom-scrollable href='#position-2'}}
+    Position 2
+    {{/scroll-to-custom-scrollable}}
+  </div>
+
+  <div>
+    {{#scroll-to-custom-scrollable href='#position-3'}}
+    Position 3
+    {{/scroll-to-custom-scrollable}}
+  </div>
+</div>
+
+<div id='scrollable-container' style='overflow-y: auto; height: 800px; width: 200px; border: 1px solid lime;'>
+  <div class='spacer' style='height: 400px;'></div>
+  <div class='spacer' style='height: 400px;'></div>
+  <div class='spacer' style='height: 400px;'></div>
+
+  <div id='position-1' style='height: 400px; background-color: lime;'>
+    Position 1 scroll destination
+  </div>
+
+  <div class='spacer' style='height: 400px;'></div>
+  <div class='spacer' style='height: 400px;'></div>
+  <div class='spacer' style='height: 400px;'></div>
+
+  <div id='position-2' style='height: 400px; background-color: lime;'>
+    Position 2 scroll destination
+  </div>
+
+  <div class='spacer' style='height: 400px;'></div>
+  <div class='spacer' style='height: 400px;'></div>
+  <div class='spacer' style='height: 400px;'></div>
+
+  <div id='position-3' style='height: 400px; background-color: lime;'>
+    Position 3 scroll destination
+  </div>
+
+  <div class='spacer' style='height: 400px;'></div>
+  <div class='spacer' style='height: 400px;'></div>
+  <div class='spacer' style='height: 400px;'></div>
+</div>
+
+{{outlet}}

--- a/tests/dummy/app/templates/simple.hbs
+++ b/tests/dummy/app/templates/simple.hbs
@@ -1,0 +1,58 @@
+<h2>This demonstrates scrolling when the scrollable container is the body</h2>
+
+<div style='position: fixed; top: 40px; right: 40px; color: black; background-color: lightGrey; padding: 5px;'>
+  <h3 style='color: black;'>Scroll Nav Menu</h3>
+  <div>
+    {{#scroll-to href='body'}}
+    Position TOP OF BODY
+    {{/scroll-to}}
+  </div>
+
+  <div>
+    {{#scroll-to href='#position-1'}}
+    Position 1
+    {{/scroll-to}}
+  </div>
+
+  <div>
+    {{#scroll-to href='#position-2'}}
+    Position 2
+    {{/scroll-to}}
+  </div>
+
+  <div>
+    {{#scroll-to href='#position-3'}}
+    Position 3
+    {{/scroll-to}}
+  </div>
+</div>
+
+<div class='spacer' style='height: 400px;'>Spacer</div>
+<div class='spacer' style='height: 400px;'>Spacer</div>
+<div class='spacer' style='height: 400px;'>Spacer</div>
+
+<div id='position-1' style='height: 400px; background-color: lime;'>
+  Position 1 scroll destination
+</div>
+
+<div class='spacer' style='height: 400px;'>Spacer</div>
+<div class='spacer' style='height: 400px;'>Spacer</div>
+<div class='spacer' style='height: 400px;'>Spacer</div>
+
+<div id='position-2' style='height: 400px; background-color: lime;'>
+  Position 2 scroll destination
+</div>
+
+<div class='spacer' style='height: 400px;'>Spacer</div>
+<div class='spacer' style='height: 400px;'>Spacer</div>
+<div class='spacer' style='height: 400px;'>Spacer</div>
+
+<div id='position-3' style='height: 400px; background-color: lime;'>
+  Position 3 scroll destination
+</div>
+
+<div class='spacer' style='height: 400px;'>Spacer</div>
+<div class='spacer' style='height: 400px;'>Spacer</div>
+<div class='spacer' style='height: 400px;'>Spacer</div>
+
+{{outlet}}


### PR DESCRIPTION
Adds method to get the scrollableTop of the scrollable container from which to offset the targets top position, this method will only offset the targets top when the container's top is offset

Adds 2 new pages to the dummy app to demonstrate this lib and how it is
expected to work

Fixes #36
Patches PR #25