### PR TITLE
Update scroller.js

### DIFF
--- a/addon/services/scroller.js
+++ b/addon/services/scroller.js
@@ -24,7 +24,7 @@ export default Em.Service.extend({
   getJQueryElement (target) {
     const jQueryElement = Em.$(target);
 
-    if (!jQueryElement) {
+    if (Em.isEmpty(jQueryElement)) {
       Em.Logger.warn("element couldn't be found:", target);
       return;
     }


### PR DESCRIPTION
Use a safer approach to testing truthiness - the selection here returns an Empty object if it can't be found, but that is truthy.