### PR TITLE
improve vertical coordinate calculation

### DIFF
--- a/tests/acceptance/custom-scrollable-test.js
+++ b/tests/acceptance/custom-scrollable-test.js
@@ -1,0 +1,44 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import { later } from '@ember/runloop';
+import Ember from 'ember';
+
+moduleForAcceptance('Acceptance | custom scrollable');
+
+test('visiting /custom-scrollable', function(assert) {
+  visit('/custom-scrollable');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/custom-scrollable', 'current url is correct');
+  });
+
+  // Scroll to position-1
+  andThen(function() {
+    click('a.test-scroll-to-position-1');
+    later(() => console.log("wait for scroll"), 1000);
+  });
+  andThen(function() {
+    let top = document.getElementById('position-1').getBoundingClientRect().top;
+    assert.equal(top, Ember.$('#scrollable-container').offset().top, 'After clicking on position-1 it should be at the top of the page');
+  });
+
+  // While at position-1, scroll _down_ to position-2
+  andThen(function() {
+    click('a.test-scroll-to-position-2');
+    later(() => console.log("wait for scroll"), 1000);
+  });
+  andThen(function() {
+    let top = document.getElementById('position-2').getBoundingClientRect().top;
+    assert.equal(top, Ember.$('#scrollable-container').offset().top, 'After clicking on position-2 it should be at the top of the page');
+  });
+
+  // While at position-2, scroll _up_ to position-1
+  andThen(function() {
+    click('a.test-scroll-to-position-1');
+    later(() => console.log("wait for scroll"), 1000);
+  });
+  andThen(function() {
+    let top = document.getElementById('position-1').getBoundingClientRect().top;
+    assert.equal(top, Ember.$('#scrollable-container').offset().top, 'After clicking on position-1 it should be at the top of the page');
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,7 +8,7 @@ const Router = Ember.Router.extend({
 
 Router.map(function() {
   this.route('simple');
-  this.route('customScrollable');
+  this.route('custom-scrollable');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -7,7 +7,7 @@
 </div>
 
 <div>
-  {{#link-to 'customScrollable'}}
+  {{#link-to 'custom-scrollable'}}
   Custom Scrollable
   {{/link-to}}
 </div>

--- a/tests/dummy/app/templates/custom-scrollable.hbs
+++ b/tests/dummy/app/templates/custom-scrollable.hbs
@@ -2,20 +2,21 @@
 
 <div style='position: fixed; top: 40px; right: 40px; color: black; background-color: lightGrey; padding: 5px;'>
   <h3 style='color: black;'>Scroll Nav Menu</h3>
+
   <div>
-    {{#scroll-to-custom-scrollable href='#position-1'}}
+    {{#scroll-to-custom-scrollable class='test-scroll-to-position-1' href='#position-1'}}
     Position 1
     {{/scroll-to-custom-scrollable}}
   </div>
 
   <div>
-    {{#scroll-to-custom-scrollable href='#position-2'}}
+    {{#scroll-to-custom-scrollable class='test-scroll-to-position-2' href='#position-2'}}
     Position 2
     {{/scroll-to-custom-scrollable}}
   </div>
 
   <div>
-    {{#scroll-to-custom-scrollable href='#position-3'}}
+    {{#scroll-to-custom-scrollable class='test-scroll-to-position-3' href='#position-3'}}
     Position 3
     {{/scroll-to-custom-scrollable}}
   </div>


### PR DESCRIPTION
- Enables creating passing acceptance tests
- Fixes a bug in `getScrollableTop` which incorrectly treats
`this.get('scrollable').offset().top === 0` as though the user did not
override `scrollable`

Fixes https://github.com/ragnarpeterson/ember-scroll-to/issues/43